### PR TITLE
Enhance map generator with prefab matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # ArmaMapGen
 
-This repository contains a prototype script for generating Arma Reforger map data from real world locations. The script uses OpenStreetMap to fetch roads and building footprints and SRTM elevation data to create a simple heightmap.
+This repository contains a prototype script for generating Arma Reforger map data from real world locations. The script uses OpenStreetMap to fetch roads and building footprints and SRTM elevation data to create a simple heightmap.  
+Building footprints are analysed to approximate size and orientation and then matched against a small set of example Arma building prefabs.
 
 ## Usage
 
 ```bash
-pip install -r requirements.txt  # install dependencies (osmnx, rasterio, pillow, numpy, SRTM.py)
+pip install -r requirements.txt  # install dependencies (osmnx, rasterio, pillow, numpy, SRTM.py, shapely)
 python generate_map.py --north <lat> --south <lat> --east <lon> --west <lon> --size 512 --outdir output
 ```
 
-The script will create `heightmap.png`, `roads.json`, and `buildings.json` in the specified output directory.
+The script will create `heightmap.png`, `roads.json`, and `buildings.json` in the specified output directory.  
+Each building entry now contains a chosen prefab name, rotation angle and approximate dimensions.

--- a/generate_map.py
+++ b/generate_map.py
@@ -5,6 +5,8 @@ from PIL import Image
 import numpy as np
 import json
 import argparse
+import math
+from shapely.geometry import Polygon
 
 
 def fetch_heightmap(north, south, east, west, size=512):
@@ -31,17 +33,58 @@ def fetch_heightmap(north, south, east, west, size=512):
 def extract_buildings(north, south, east, west):
     tags = {'building': True}
     gdf = ox.features_from_bbox((west, south, east, north), tags)
+
+    prefabs = [
+        {"name": "Small_House_A", "width": 10, "length": 8},
+        {"name": "Warehouse_B", "width": 30, "length": 20},
+        {"name": "Apartment_Block_C", "width": 40, "length": 15},
+    ]
+
+    def match_prefab(w, l):
+        best = None
+        best_score = float("inf")
+        for p in prefabs:
+            score = abs(p["width"] - w) + abs(p["length"] - l)
+            if score < best_score:
+                best_score = score
+                best = p["name"]
+        return best
+
     buildings = []
     for _, row in gdf.iterrows():
-        if row.geometry is None:
+        geom = row.geometry
+        if geom is None:
             continue
-        if row.geometry.geom_type == 'Polygon':
-            coords = list(row.geometry.exterior.coords)
-        elif row.geometry.geom_type == 'MultiPolygon':
-            coords = list(row.geometry.geoms[0].exterior.coords)
-        else:
+        poly = None
+        if geom.geom_type == 'Polygon':
+            poly = geom
+        elif geom.geom_type == 'MultiPolygon':
+            poly = geom.geoms[0]
+        if poly is None:
             continue
-        buildings.append({'coords': coords})
+
+        coords = list(poly.exterior.coords)
+        rect = poly.minimum_rotated_rectangle
+        rect_coords = list(rect.exterior.coords)
+        side_lengths = [
+            math.hypot(rect_coords[i+1][0] - rect_coords[i][0], rect_coords[i+1][1] - rect_coords[i][1])
+            for i in range(4)
+        ]
+        width, length = sorted(side_lengths)[0:2]
+        dx = rect_coords[1][0] - rect_coords[0][0]
+        dy = rect_coords[1][1] - rect_coords[0][1]
+        orientation = (math.degrees(math.atan2(dy, dx)) + 360) % 360
+        prefab = match_prefab(width, length)
+        centroid = poly.centroid
+
+        buildings.append({
+            'coords': coords,
+            'prefab': prefab,
+            'position': [centroid.y, centroid.x],
+            'orientation': orientation,
+            'width': width,
+            'length': length,
+        })
     return buildings
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ rasterio
 pillow
 numpy
 SRTM.py
+shapely


### PR DESCRIPTION
## Summary
- compute oriented bounding boxes for building footprints
- match buildings to example Arma prefabs
- emit prefab name, orientation and dimensions in output
- document the new feature
- include `shapely` in requirements

## Testing
- `python -m py_compile generate_map.py`

------
https://chatgpt.com/codex/tasks/task_e_6871c0ab58bc8323b778b07b2c98c4da