### PR TITLE
Enhance prototype with town detection and prop scattering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Building footprints are analysed to approximate size and orientation and then ma
 ## Usage
 
 ```bash
-pip install -r requirements.txt  # install dependencies (osmnx, rasterio, pillow, numpy, SRTM.py, shapely)
+pip install -r requirements.txt  # install dependencies (osmnx, rasterio, pillow, numpy, SRTM.py, shapely, scikit-learn)
 python generate_map.py --north <lat> --south <lat> --east <lon> --west <lon> --size 512 --outdir output
 ```
 
-The script will create `heightmap.png`, `roads.json`, and `buildings.json` in the specified output directory.  
-Each building entry now contains a chosen prefab name, rotation angle and approximate dimensions.
+The script will create `heightmap.png`, `roads.json`, `buildings.json` and `scatter_props.json` in the specified output directory.
+Each building entry contains a chosen prefab name, rotation angle and approximate dimensions. The script clusters buildings into towns using DBSCAN and scatters simple props (street lights, mailboxes, benches) around clustered buildings.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pillow
 numpy
 SRTM.py
 shapely
+scikit-learn


### PR DESCRIPTION
## Summary
- detect building clusters with DBSCAN
- scatter simple props around clustered buildings
- output new `scatter_props.json`
- document new features and add scikit-learn requirement

## Testing
- `pip install -r requirements.txt`
- `pip install scikit-learn`
- `python generate_map.py --north 45.525 --south 45.52 --east -122.66 --west -122.68 --size 32 --outdir test_output`

------
https://chatgpt.com/codex/tasks/task_e_6871d188f0388323a85167f0055d10d2