### PR TITLE
Improve prefab selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # ArmaMapGen
 
 This repository contains a prototype script for generating Arma Reforger map data from real world locations. The script uses OpenStreetMap to fetch roads and building footprints and SRTM elevation data to create a simple heightmap.  
-Building footprints are analysed to approximate size and orientation and then matched against a small set of example Arma building prefabs.
+Building footprints are analysed to approximate size and orientation and then matched against example Arma building prefabs.  
+Basic building type detection (residential, commercial, industrial) chooses a more appropriate prefab for each footprint.
 
 ## Usage
 
@@ -9,6 +10,7 @@ Building footprints are analysed to approximate size and orientation and then ma
 pip install -r requirements.txt  # install dependencies (osmnx, rasterio, pillow, numpy, SRTM.py, shapely, scikit-learn)
 python generate_map.py --north <lat> --south <lat> --east <lon> --west <lon> --size 512 --outdir output
 ```
+The bounding box parameters follow the order **north, south, east, west** as required by OSMnx.
 
 The script will create `heightmap.png`, `roads.json`, `buildings.json` and `scatter_props.json` in the specified output directory.
 Each building entry contains a chosen prefab name, rotation angle and approximate dimensions. The script clusters buildings into towns using DBSCAN and scatters simple props (street lights, mailboxes, benches) around clustered buildings.


### PR DESCRIPTION
## Summary
- detect rough building types when parsing OSM data
- match buildings using type-specific prefab lists
- document bounding box order and prefab selection in README

## Testing
- `pip install -r requirements.txt`
- `python generate_map.py --north 45.52 --south 45.51 --east -122.67 --west -122.68 --size 32 --outdir tmp_output`


------
https://chatgpt.com/codex/tasks/task_e_6871eb8cd9948323af92792a1ef430ac